### PR TITLE
registration_header

### DIFF
--- a/app/views/users/shared/_registration-header.html.haml
+++ b/app/views/users/shared/_registration-header.html.haml
@@ -1,0 +1,5 @@
+.newmember_registration__container
+    .newmember_registration__header
+      %h1.newmember_registration__header__logo
+        = image_tag('https://www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1881812696')
+    


### PR DESCRIPTION
＃WHAT
ヘッダー部分の切り離し

＃WHY
汎用性を求めて