### PR TITLE
販売価格設定の実装

### DIFF
--- a/app/assets/javascripts/dropzone.js
+++ b/app/assets/javascripts/dropzone.js
@@ -158,7 +158,7 @@ $(document).on("turbolinks:load", function() {
     var formData = new formData($(this).get(0));
 
     if (upload_images.length == 0) {
-      form.Data.append("new_images[images][]", " ")
+      formData.append("new_images[images][]", " ")
       
     } else {
       

--- a/app/assets/javascripts/price.js
+++ b/app/assets/javascripts/price.js
@@ -1,0 +1,19 @@
+$(function() {
+  
+  $('#price-form').on('input', function () {
+    var inputPrice = $('#price-form').val();
+    var fee = inputPrice * 0.1;
+    var usersBenefit = inputPrice - fee;
+    
+    if(fee > 10 && inputPrice !== '' && inputPrice <= 9999999) {
+      var fee = String(fee).replace(/(\d)(?=(\d\d\d)+$)/g, "$1,");
+      $('#sales-fee').text(fee);
+      var usersBenefit = String(usersBenefit).replace(/(\d)(?=(\d\d\d)+$)/g, "$1,");
+      $('#sales-benefit').text(usersBenefit);
+    }else{
+      $('#sales-fee').text("-");
+      $('#sales-benefit').text("-");
+    };
+
+  });
+})

--- a/app/assets/stylesheets/_sell.scss
+++ b/app/assets/stylesheets/_sell.scss
@@ -300,6 +300,7 @@
                     .btn-gray {
                         width: 45%;
                         margin: 24px auto 0;
+                        color: $bg-white;
                     }
                 }
             }

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,5 +1,4 @@
 class Image < ApplicationRecord
   mount_uploader :image, ImageUploader
-
   belongs_to :products
 end

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -107,28 +107,28 @@
             %h3.sell-content__sub-head
               販売価格(300〜9,999,999)
             = link_to "",{ target: "_blank", class: "form-question" } do
-              %i.fa.fa-question-circle
+              = fa_icon "question-circle"
             .sell-content__form-box
               %ul.sell-price
                 %li.form-group
                   .clearfix
-                    %label.l-left
+                    = f.label :price, class: "l-left" do
                       価格
                       %span.form-require
                         必須
                     .l-right.sell-price-input
                       ¥
                       %div
-                        %input{ class: "input-default", value: "", placeholder: "例）300" }
+                        = f.text_field :price, class: "input-default", id: "price-form", value: "", placeholder: "例）300" 
                 %li.clearfix
                   .l-left
                     販売手数料 (10%)
-                  .l-right
+                  .l-right#sales-fee
                     \-
                 %li.clearfix.bold
                   .l-left
                     販売利益
-                  .l-right
+                  .l-right#sales-benefit
                     \-
           .modal{ role: "dialog", tabindex: "-1" }
             .modal-inner
@@ -151,8 +151,8 @@
                 = link_to "/jp/seller_terms/" do
                   加盟店規約
                 に同意したことになります。
-            %button{ type: "submit", class: "btn-default btn-red", id: "new-product" }
-              出品する
-            %button.btn-default.btn-gray
+            = f.submit "出品する", class: "btn-default btn-red", id: "new-product" 
+              
+            = link_to root_path, class: "btn-default btn-gray" do
               もどる
 = render partial: "users/shared/registration-footer"


### PR DESCRIPTION
## WHAT
販売価格を入力し、販売手数料と販売利益を同時に表示できるように実装。

##WHY
出品する商品の価格を設定
さらに入力された価格を元に、販売手数料と販売利益を表示し、確認できるようにするため。

[![Image from Gyazo](https://i.gyazo.com/1fed7a563f8564abad95a81feae75845.gif)](https://gyazo.com/1fed7a563f8564abad95a81feae75845)