### PR TITLE
Fix item_category

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -7,8 +7,8 @@ class ProductsController < ApplicationController
   def index
     @ladies = Product.recent_category(1..218)
     @mens = Product.recent_category(219..377)
-    @kids = Product.recent_category(378..529)
-    @cosmes = Product.recent_category(528..714)
+    @kids = Product.recent_category(378..527)
+    @cosmes = Product.recent_category(528..638)
     @channels = Product.recent_brand(1)
     @vuittons = Product.recent_brand(2)
     @supremes = Product.recent_brand(3)


### PR DESCRIPTION
#WHAT 
 トップページ　その他で出品した際に「コスメ」のところに商品が掲載されてしまう事象を解消