### PR TITLE
商品出品時のバグの解消

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -169,7 +169,7 @@ class ProductsController < ApplicationController
   private
 
   def product_params
-    params.require(:product).permit(:name, :detail, :condition_id, :price, :status_id, :brand_id, :category_id, :size_id, :charge_id, :prefecture_id, :delivery_method_id, :shipment_id, images_attributes: {image: []}).merge(user_id: current_user.id)
+    params.require(:product).permit(:name, :detail, :condition_id, :price, :status_id, :brand_id, :category_id, :size_id, :charge_id, :prefecture_id, :delivery_method_id, :shipment_id).merge(user_id: current_user.id)
   end
 
   def update_params
@@ -191,5 +191,9 @@ class ProductsController < ApplicationController
 
   def set_product
     @product = Product.find(params[:id])
+  end
+
+  def image_params
+    params(:images).require({image: []})
   end
 end

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -13,13 +13,13 @@
                 必須
             %p
               最大10枚までアップロードできます
-            = f.fields_for :images do |image|
+            = f.fields_for :images, @product.images.first do |image|
               .dropzone-container.clearfix
                 #preview
                 .dropzone-container__upload
                   =image.label :image, class: "dropzone-container__drop-field", for: "upload-image" do
                     .dropzone-container__upload-area
-                      = image.file_field :image, multiple: true, name: 'images[image][]', id: "upload-image", class: "upload-image", 'data-image': 0
+                      = image.file_field :image, id: "upload-image", class: "upload-image", 'data-image': 0
                       .dz-message.needsclick
                         %p  
                           ドラッグアンドドロップ
@@ -30,7 +30,7 @@
                 .dropzone-container__upload2
                   =image.label :image, class: "dropzone-container__drop-field2", for: "upload-image" do
                     .dropzone-container__upload-area
-                      = image.file_field :image, multiple: true, name: 'images[image][]', id: "upload-image", class: "upload-image", 'data-image': 0
+                      = image.file_field :image, id: "upload-image", class: "upload-image", 'data-image': 0
                       .dz-message.needsclick
                         %p  
                           ドラッグアンドドロップ

--- a/spec/factories/image.rb
+++ b/spec/factories/image.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
 
-  factory :product do
+  factory :image do
     image    { File.open("#{Rails.root}/spec/images/289CAEA9-8DA7-45A1-917A-EFFD0FDFF294.jpg")}
   end
 end


### PR DESCRIPTION
## WHAT
商品出品で画像の削除ボタンを押しても商品が消えないバグ

## WHY
商品画像の枚数を適正化